### PR TITLE
Changing ^M chars to semicolons

### DIFF
--- a/bin/git_rails
+++ b/bin/git_rails
@@ -13,7 +13,7 @@ fi
 files_changed=`git diff $old_ref $new_ref --name-status`
 
 # CHECK IF WE NEED TO DO A BUNDLE
-bundle_changed=`echo "$files_changed" | egrep 'M\tGemfile.lock'` 
+bundle_changed=`echo "$files_changed" | egrep 'M\tGemfile.lock'`
 if [ ! -z "$bundle_changed" ]; then
   echo "Your Gemfile.lock has changed, running bundle"
   bundle
@@ -42,15 +42,15 @@ if [ ! -z "$migrations" ]; then
       # CHECKOUT DOWN MIGRATION AND SAVE PATH FOR CLEANUP
       git checkout "$old_ref" -- "$migration"
       migration_cleanup="$migration_cleanup $migration"
-      migrate_commands="$migrate_command$migrate_commands"
+      migrate_commands="$migrate_command;$migrate_commands"
     else
-      migrate_commands="$migrate_commands$migrate_command"
+      migrate_commands="$migrate_commands;$migrate_command"
     fi
   done
 
   # RUN THE MIGRATIONS (AND TEST PREPARE)
   test_prepare="require 'rake';Rails.application.load_tasks;Rake::Task['db:test:prepare'].invoke"
-  migrate_commands="$migrate_commands$test_prepare"
+  migrate_commands="$migrate_commands;$test_prepare;"
   echo "$migrate_commands" | bundle exec rails c > /dev/null
 
   # CLEAN UP DOWN MIGRATIONS


### PR DESCRIPTION
Thanks for this tool - it's a huge help for me.

In order to get migrations to work in my environment (MacOSX Mavericks, Rails 4.1.5, Ruby 2.1.2p95), I needed to change all instances of the `^M` character with a semicolon instead. Otherwise I would get the following error, and no migrations would run:

```
$ git checkout master
Switched to branch 'master'
Running migrations!
(irb):1: warning: encountered \r in middle of line, treated as a mere space
```

Hope this patch helps.