### PR TITLE
Add db:_dump task at the end of migrations.

### DIFF
--- a/bin/git_rails
+++ b/bin/git_rails
@@ -48,6 +48,10 @@ if [ ! -z "$migrations" ]; then
     fi
   done
 
+  # DUMP UPDATED DB SCHEMA AFTER MIGRATIONS HAVE RUN
+  db_dump_command="require 'rake';Rails.application.load_tasks;Rake::Task['db:_dump'].invoke"
+  migrate_commands="$migrate_commands;$db_dump_command"
+
   # RUN THE MIGRATIONS (AND TEST PREPARE)
   echo "$migrate_commands" | bundle exec rails c > /dev/null
 


### PR DESCRIPTION
Possible solution to #7. 

Still need to resolve schema.rb/structure.sql conflicts on merge/rebase. Maybe one solution could be to use a custom merge driver as seen in [hookup](https://github.com/tpope/hookup/blob/master/lib/hookup.rb#L63)? 
