### PR TITLE
Command line options for dry run and verbose output 

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,19 @@ Or if you really know what you are doing and you want to pretend like you are on
 
 Migrations that were added between `REF_YOU_CAME_FROM` and `REF_YOU_ARE_GOING_TO` that do not exist on your current `HEAD` will not be applied because they don't exist!!
 
+#### Options
+
+The following command line options are supported:
+
+* -v, --verbose
+  * Display pending changes, prompt to continue, display command output
+* -y, --auto_confirm
+  * Variant of verbose mode; display pending changes but do not prompt before applying them
+* -d, --dry_run
+  * Display pending changes and exit
+* -h, --help
+  * Display usage and exit
+
 #### Hooks
 
 You shouldn't have to think about the hooks once they are installed. Just pull, checkout, and rebase as normal and they should work fine. If you find that `git_rails` hasn't fired when it should follow the command instructions to run it manually.

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ The following command line options are supported:
 * -v, --verbose
   * Display pending changes, prompt to continue, display command output
 * -y, --auto_confirm
-  * Variant of verbose mode; display pending changes but do not prompt before applying them
+  * Use in conjunction with verbose mode to apply pending changes without prompting
 * -d, --dry_run
   * Display pending changes and exit
 * -h, --help

--- a/README.md
+++ b/README.md
@@ -6,13 +6,13 @@ Manage bundle and migrations automatically while you use git!
 For example:
 
 - If you pull down code from your remote and there are new or updated gems
- * it will run `bundle` for you
+  * it will run `bundle` for you
 - If you checkout a branch that uses a different set of migrations
- * it will roll back the old set and apply the new ones
+  * it will roll back the old set and apply the new ones
 - If you rebase and there are new gems and migrations
- * it will run `bundle` and `rake db:migrate test:prepare`
+  * it will run `bundle` and `rake db:migrate test:prepare`
 - If you don't like automagical git hooks
- * run `git_rails` and it will try and find out where you came from and run the same check
+  * run `git_rails` and it will try and find out where you came from and run the same check
 
 ### Install
 

--- a/bin/git_rails
+++ b/bin/git_rails
@@ -1,4 +1,65 @@
 #!/bin/bash
+
+function help {
+  echo -e "\nUsage:"
+  echo -e "\tgit-rails [-d] [-v] [-y] [old_ref] [new_ref]"
+  echo -e "\tgit-rails -h"
+  echo "Flags:"
+  echo -e "\t-d\tdry-run: display pending changes and exit"
+  echo -e "\t-v\tverbose: display pending changes, prompt to continue, display command output"
+  echo -e "\t-y\tauto-confirm: in verbose mode, do not prompt after displaying pending changes"
+  echo
+  exit 0
+}
+
+dry_run=0
+verbose=0
+confirm=0
+out_target="/dev/null"
+
+optspec=":vdyh-:"
+while getopts "$optspec" optchar; do
+  case "${optchar}" in
+    -)
+      case "${OPTARG}" in
+        dry-run | dry_run)
+          dry_run=1
+          verbose=1
+          ;;
+        verbose)
+          verbose=1
+          confirm=1
+          out_target="/dev/stdout"
+          ;;
+        auto-confirm | auto_confirm)
+          confirm_opt=0
+          ;;
+        help)
+          help
+          ;;
+      esac;;
+    d)
+      dry_run=1
+      verbose=1
+      ;;
+    v)
+      verbose=1
+      confirm=1
+      out_target="/dev/stdout"
+      ;;
+    y)
+      confirm_opt=0
+      ;;
+    h)
+      help
+      ;;
+  esac
+done
+if [ "$verbose" -eq 1 -a ! -z "$confirm_opt" ]; then
+  confirm=$confirm_opt
+fi
+shift $((OPTIND -1))
+
 old_ref=$1
 new_ref=$2
 
@@ -14,12 +75,36 @@ files_changed=`git diff $old_ref $new_ref --name-status`
 
 # CHECK IF WE NEED TO DO A BUNDLE
 bundle_changed=`echo "$files_changed" | grep $'M\tGemfile.lock'`
+
+migrations=`git diff --name-status $old_ref $new_ref -- db/migrate | grep '^[AD]'`
+
+if [ "$verbose" -eq 1 ]; then
+  if [ ! -z "$bundle_changed" ]; then
+    echo -e "\nPrep needed:"
+    echo -e "\t- bundle"
+  fi
+  if [ ! -z "$migrations" ]; then
+    echo -e "\nMigrations needed:\n${migrations}"
+  fi
+  if [ -z "$bundle_changed" -a -z "$migrations" ]; then
+    echo -e "\nNo changes necessary\n"
+    exit 0
+  fi
+  echo
+  if [ "$dry_run" -eq 1 ]; then
+    exit 0
+  elif [ "$confirm" -eq 1 ]; then
+    read -p "Continue? [Yn]: " confirm
+    [[ $confirm =~ ^[Nn] ]] && echo && exit 0
+  fi
+fi
+
+# okay, now actually run whatever's needed
 if [ ! -z "$bundle_changed" ]; then
   echo "Your Gemfile.lock has changed, running bundle"
   bundle
 fi
 
-migrations=`git diff --name-status $old_ref $new_ref -- db/migrate | grep '^[AD]'`
 if [ ! -z "$migrations" ]; then
   echo "Running migrations!"
   for migration in $migrations
@@ -49,7 +134,9 @@ if [ ! -z "$migrations" ]; then
   done
 
   # RUN THE MIGRATIONS (AND TEST PREPARE)
-  echo "$migrate_commands" | bundle exec rails c > /dev/null
+  {
+    echo "$migrate_commands" | bundle exec rails c
+  } > $out_target
 
   # CLEAN UP DOWN MIGRATIONS
   if [ ! -z "$migration_cleanup" ]; then

--- a/bin/git_rails
+++ b/bin/git_rails
@@ -7,7 +7,7 @@ function help {
   echo "Flags:"
   echo -e "\t-d\tdry-run: display pending changes and exit"
   echo -e "\t-v\tverbose: display pending changes, prompt to continue, display command output"
-  echo -e "\t-y\tauto-confirm: in verbose mode, do not prompt after displaying pending changes"
+  echo -e "\t-y\tauto-confirm: in verbose mode, apply pending changes without prompting"
   echo
   exit 0
 }

--- a/bin/git_rails
+++ b/bin/git_rails
@@ -14,7 +14,7 @@ function help {
   echo -e "\tdest_ref\tBranch/ref you're ending at; defaults to HEAD"
   echo -e "\t\t\tUse with care; see README for more details"
   echo
-  echo -e "Web: https://github.com/jfouse/git-rails"
+  echo -e "Web: https://github.com/brysgo/git-rails"
   echo
   exit 0
 }

--- a/bin/git_rails
+++ b/bin/git_rails
@@ -76,17 +76,25 @@ files_changed=`git diff $old_ref $new_ref --name-status`
 # CHECK IF WE NEED TO DO A BUNDLE
 bundle_changed=`echo "$files_changed" | grep $'M\tGemfile.lock'`
 
+# CHECK IF WE NEED TO SPIN SOME YARN
+yarn_changed=`echo "$files_changed" | grep $'M\tyarn.lock'`
+
 migrations=`git diff --name-status $old_ref $new_ref -- db/migrate | grep '^[AD]'`
 
 if [ "$verbose" -eq 1 ]; then
-  if [ ! -z "$bundle_changed" ]; then
+  if [ ! -z "$bundle_changed" -o ! -z "$yarn_changed" ]; then
     echo -e "\nPrep needed:"
-    echo -e "\t- bundle"
+    if [ ! -z "$bundle_changed" ]; then
+      echo -e "\t- bundle"
+    fi
+    if [ ! -z "$yarn_changed" ]; then
+      echo -e "\t- yarn"
+    fi
   fi
   if [ ! -z "$migrations" ]; then
     echo -e "\nMigrations needed:\n${migrations}"
   fi
-  if [ -z "$bundle_changed" -a -z "$migrations" ]; then
+  if [ -z "$bundle_changed" -a -z "$yarn_changed" -a -z "$migrations" ]; then
     echo -e "\nNo changes necessary\n"
     exit 0
   fi
@@ -103,6 +111,11 @@ fi
 if [ ! -z "$bundle_changed" ]; then
   echo "Your Gemfile.lock has changed, running bundle"
   bundle
+fi
+
+if [ ! -z "$yarn_changed" ]; then
+  echo "Your yarn.lock has changed, running yarn"
+  yarn
 fi
 
 if [ ! -z "$migrations" ]; then

--- a/bin/git_rails
+++ b/bin/git_rails
@@ -2,12 +2,19 @@
 
 function help {
   echo -e "\nUsage:"
-  echo -e "\tgit-rails [-d] [-v] [-y] [old_ref] [new_ref]"
+  echo -e "\tgit-rails [-d] [-v] [-y] [src_ref] [dest_ref]"
   echo -e "\tgit-rails -h"
   echo "Flags:"
   echo -e "\t-d\tdry-run: display pending changes and exit"
   echo -e "\t-v\tverbose: display pending changes, prompt to continue, display command output"
   echo -e "\t-y\tauto-confirm: in verbose mode, apply pending changes without prompting"
+  echo
+  echo -e "\tsrc_ref\t\tBranch/ref you're coming from; defaults to ORIG_HEAD"
+  echo
+  echo -e "\tdest_ref\tBranch/ref you're ending at; defaults to HEAD"
+  echo -e "\t\t\tUse with care; see README for more details"
+  echo
+  echo -e "Web: https://github.com/jfouse/git-rails"
   echo
   exit 0
 }


### PR DESCRIPTION
I'm often jumping between feature branches, and sometimes I have some testing data in new columns or tables that I don't want to lose just because I jumped to another branch to fix or tweak something.  I've added support for a few command line switches that alter the behavior a bit as follows, though usage without any switches should remain consistent with existing functionality:

* -v, --verbose
  * Display pending changes, prompt to continue, display command output
  * Handles the need identified in PR #6 
* -y, --auto_confirm
  * Use in conjunction with verbose mode to apply pending changes without prompting
* -d, --dry_run
  * Display pending changes and exit
* -h, --help
  * Display usage and exit

I fully realize this isn't actively maintained and nobody may care, but I thought I'd at least log a PR for anyone wandering by to find. 