### PR TITLE
Make it work when Rails project is not in repository root

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,3 +61,15 @@ The following command line options are supported:
 You shouldn't have to think about the hooks once they are installed. Just pull, checkout, and rebase as normal and they should work fine. If you find that `git_rails` hasn't fired when it should follow the command instructions to run it manually.
 
 Also, the hooks are optional, you can use `git_rails` without them!
+
+#### Monorepo usage
+
+If the Rails project is not in the root of the Git repository, execute `git_rails` and hooks in the Rails directory.
+
+For example, to make the post-checkout hook run in a particular subdirectory, create the following `.git/hooks/post-checkout` file:
+
+```sh
+#!/bin/sh
+cd path/to/rails/project
+exec /path/to/git_rails/hooks/post-checkout "$@"
+```

--- a/bin/git_rails
+++ b/bin/git_rails
@@ -137,14 +137,14 @@ if [ ! -z "$migrations" ]; then
     fi
 
     # BUILD THE MIGRATION COMMAND FROM THE VERSION AND TYPE
-    version=`echo "$migration" | cut -d'_' -f1 | cut -d'/' -f3`
+    version=`echo "$migration" | grep -o 'db/migrate/.*' | cut -d'_' -f1 | cut -d'/' -f3`
     migrate_command="ActiveRecord::Migrator.run(:$migration_type, 'db/migrate', $version) rescue nil"
 
     # APPEND OR PREPREND TO THE COMMAND LIST DEPENDING ON MIGRATION TYPE
     if [[ $migration_type == "down" ]]; then
       # CHECKOUT DOWN MIGRATION AND SAVE PATH FOR CLEANUP
-      git checkout "$old_ref" -- "$migration"
-      migration_cleanup="$migration_cleanup $migration"
+      git checkout "$old_ref" -- ":/$migration"
+      migration_cleanup="$migration_cleanup $(git ls-files :/$migration)"
       migrate_commands="$migrate_command;$migrate_commands"
     else
       migrate_commands="$migrate_commands;$migrate_command"

--- a/bin/git_rails
+++ b/bin/git_rails
@@ -78,13 +78,11 @@ if [ -z "$new_ref" ]; then
   new_ref=`git rev-parse HEAD`
 fi
 
-files_changed=`git diff $old_ref $new_ref --name-status`
-
 # CHECK IF WE NEED TO DO A BUNDLE
-bundle_changed=`echo "$files_changed" | grep $'M\tGemfile.lock'`
+bundle_changed=`git diff $old_ref $new_ref -- Gemfile.lock`
 
 # CHECK IF WE NEED TO SPIN SOME YARN
-yarn_changed=`echo "$files_changed" | grep $'M\tyarn.lock'`
+yarn_changed=`git diff $old_ref $new_ref -- yarn.lock`
 
 migrations=`git diff --name-status $old_ref $new_ref -- db/migrate | grep '^[AD]'`
 


### PR DESCRIPTION
This is useful for monorepos.

This is accomplished by making Git commands operate on relative pathspecs where we can. In case of migrations, absolute pathspecs (`:/` prefix) had to be used, because the file name comes from `git diff` output.