### PR TITLE
`rails runner` instead of `rails c`

### DIFF
--- a/bin/git_rails
+++ b/bin/git_rails
@@ -155,7 +155,7 @@ if [ ! -z "$migrations" ]; then
 
   # RUN THE MIGRATIONS (AND TEST PREPARE)
   {
-    echo "$migrate_commands" | bundle exec rails c
+    echo "$migrate_commands" | bundle exec rails runner /dev/stdin
   } > $out_target
 
   # CLEAN UP DOWN MIGRATIONS


### PR DESCRIPTION
rails console prints some tty-related errors when not connected to a terminal (such as when running in a git hook).

As suggested by @zyla in #11 